### PR TITLE
Preset "fix" for users using file: protocol

### DIFF
--- a/assets/js/func.js
+++ b/assets/js/func.js
@@ -18,3 +18,11 @@ function randomizeArray(arr) {
 function getRandomNumber(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
+
+function isHTMLLocal() {
+    if (window.location.protocol === "file:") {
+        return true;
+    }
+
+    return false;
+}

--- a/assets/js/func.js
+++ b/assets/js/func.js
@@ -7,6 +7,14 @@ function displayDiv(divId) {
     }
 }
 
+function presetDisplayDiv() {
+    if (isHTMLLocal()) {
+        displayDiv("local-preset-modal");
+    } else {
+        displayDiv("preset-modal");
+    }
+}
+
 function getYear() {
     return new Date().getFullYear();
 }

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
                         <button
                             class="main-button side-main-button"
                             id="preset-button"
-                            onclick="displayDiv('preset-modal')"
+                            onclick="presetDisplayDiv()"
                         >
                             View Presets
                         </button>
@@ -270,6 +270,26 @@
                         Amendment/Article Cards
                     </button>
                 </div>
+            </div>
+        </div>
+        <div class="modal" id="local-preset-modal" style="display: none">
+            <div class="modal-content">
+                <button
+                    class="close-button"
+                    onclick="displayDiv('local-preset-modal')"
+                >
+                    &times;
+                </button>
+                <h1>Presets Unsupported</h1>
+                <hr />
+                <p>
+                    Due to a technical limitation, you cannot load presets when
+                    locally viewing Tester. Please visit
+                    <a href="https://dacoder101.github.io/tester"
+                        >the online version of Tester</a
+                    >, or upload the preset test directly from
+                    <code>./assets/presets/</code>.
+                </p>
             </div>
         </div>
         <div class="modal" id="test-modal" style="display: none">


### PR DESCRIPTION
Browser security limitations render it impossible to access the filesystem of users (obviously), but this extends to local document viewing. There's no fix for this.

This pull requests adds a modal when a user accesses the Preset menu from a file: protocol and instructs solutions.